### PR TITLE
feat: Fix timeout and read functions

### DIFF
--- a/zigredis/comcast.sh
+++ b/zigredis/comcast.sh
@@ -20,9 +20,10 @@ else
     exit 1
 fi
 
-# if arg num is not 3, print usage
-if [[ $# -ne 3 ]]; then
-    echo "usage: comcast.sh start <device> <latency> <packet-loss>"
+# if arg num is not 3 or 2, print usage
+echo $#
+if [[ $# -ne 4 && $# -ne 1 ]]; then
+    echo "usage: comcast.sh start <device> <latency> <packet-loss>  | comcast.sh stop"
     exit 1
 fi
 
@@ -38,16 +39,16 @@ if [[ "$1" != "start" ]]; then
     exit 1
 fi
 
-
 device=$2
 latency=$3
 packet_loss=$4
 
 if [[ "$system" == "linux" ]]; then
     # $ comcast --device=eth0 --latency=250 --target-bw=1000 --default-bw=1000000 --packet-loss=10% --target-addr=8.8.8.8,10.0.0.0/24 --target-proto=tcp,udp,icmp --target-port=80,22,1000:2000
-    comcast --device=$1 --latency=$2 --target-bw=1000000 --default-bw=1000000 --packet-loss=$3% --target-addr=127.0.0.1 --target-proto=tcp --target-port=6379
+    comcast --device=${device} --latency=${latency} --target-bw=1000000 --default-bw=1000000 --packet-loss=${packet_loss}% --target-addr=127.0.0.1 --target-proto=tcp --target-port=6379
 else
     # not support ip port
-    comcast --device=$1 --latency=$2 --target-bw=1000 --packet-loss=$3%
+    # in mac, latency means src -> dst latency, not rtt time
+    comcast --device=${device} --latency=${latency} --target-bw=1000 --packet-loss=${packet_loss}%
 fi
 

--- a/zigredis/src/client.zig
+++ b/zigredis/src/client.zig
@@ -53,8 +53,6 @@ pub const Client = struct {
     pub fn read(self: *Client, buf: []u8) !usize {
         var cnt: usize = 0;
         retry: for (0..3) |_| {
-            std.debug.print("i = {d}\n", .{i});
-            var now = std.time.milliTimestamp();
             cnt = self.stream.?.read(buf) catch |err| {
                 // 只重试3次
                 if (err == std.os.ReadError.WouldBlock) {

--- a/zigredis/src/client.zig
+++ b/zigredis/src/client.zig
@@ -18,6 +18,15 @@ pub const Client = struct {
     pub fn connect(self: *Client, alloc: mem.Allocator) !void {
         // how to set keep alive
         self.stream = try net.tcpConnectToHost(alloc, self.host, self.port);
+        const timeout: std.os.timeval = .{ .tv_sec = 3, .tv_usec = 0 };
+        // set read timeout
+        try std.os.setsockopt(self.stream.?.handle, std.os.SOL.SOCKET, std.os.SO.RCVTIMEO, std.mem.toBytes(timeout)[0..]);
+        // set write timeout
+        try std.os.setsockopt(self.stream.?.handle, std.os.SOL.SOCKET, std.os.SO.SNDTIMEO, std.mem.toBytes(timeout)[0..]);
+
+        // set keep alive
+        var val: i32 = 1;
+        try std.os.setsockopt(self.stream.?.handle, std.os.SOL.SOCKET, std.os.SO.KEEPALIVE, std.mem.asBytes(&val));
     }
     pub fn deinit(self: *Client) void {
         if (self.stream) |s| {
@@ -42,8 +51,21 @@ pub const Client = struct {
     }
 
     pub fn read(self: *Client, buf: []u8) !usize {
-        var res = try self.stream.?.read(buf);
-        return res;
+        var cnt: usize = 0;
+        retry: for (0..3) |_| {
+            std.debug.print("i = {d}\n", .{i});
+            var now = std.time.milliTimestamp();
+            cnt = self.stream.?.read(buf) catch |err| {
+                // 只重试3次
+                if (err == std.os.ReadError.WouldBlock) {
+                    continue :retry;
+                }
+                // 其余错误直接返错误
+                break :retry;
+            };
+            break :retry;
+        }
+        return cnt;
     }
 };
 

--- a/zigredis/src/main.zig
+++ b/zigredis/src/main.zig
@@ -14,7 +14,7 @@ fn setupCompletion(alloc: std.mem.Allocator) !void {
     const fields = @typeInfo(req.CommandType).Enum.fields;
     inline for (fields) |field| {
         // 与C 交互的字符串一定要记得这里初始化为0
-        var buf = try alloc.alloc(u8, field.name.len + 1);
+        var buf = try alloc.alloc(u8, field.name.len);
         @memset(buf, 0);
         var name = std.ascii.lowerString(buf, field.name);
         try cmdCompleteList.append(name);


### PR DESCRIPTION
- Set read and write timeouts for the stream
- Set keep alive for the stream
- Retry reading up to 3 times in case of a 'WouldBlock' error
- Update the read function to return the number of bytes read